### PR TITLE
feat: add Hashnode blog integration + drag-and-drop for projects/expe…

### DIFF
--- a/app/blog/[slug]/blog-post-client.tsx
+++ b/app/blog/[slug]/blog-post-client.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { ArrowLeft, Calendar, Clock, Code2, User } from "lucide-react";
+import type { BlogPostDetail } from "@/lib/hashnode-api";
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export function BlogPostClient({ post }: { post: BlogPostDetail }) {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <article className="max-w-3xl mx-auto px-4 sm:px-6 py-10 sm:py-16">
+        {/* Back Link */}
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-8 group"
+        >
+          <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-1" />
+          Back to Blog
+        </Link>
+
+        {/* Cover Image or Fallback */}
+        <div className="relative w-full aspect-[2/1] rounded-xl overflow-hidden mb-8 bg-muted">
+          {post.coverImage?.url ? (
+            <Image
+              src={post.coverImage.url}
+              alt={post.title}
+              fill
+              className="object-cover"
+              priority
+              sizes="(max-width: 768px) 100vw, 768px"
+            />
+          ) : (
+            <div className="flex items-center justify-center w-full h-full bg-gradient-to-br from-primary/10 to-accent/10">
+              <Code2 className="w-24 h-24 text-primary/30" />
+            </div>
+          )}
+        </div>
+
+        {/* Title + Subtitle */}
+        <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-foreground leading-tight tracking-tight mb-3">
+          {post.title}
+        </h1>
+        {post.subtitle && (
+          <p className="text-lg sm:text-xl text-muted-foreground mb-6 leading-relaxed">
+            {post.subtitle}
+          </p>
+        )}
+
+        {/* Meta row */}
+        <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground mb-6 pb-6 border-b border-border">
+          {/* Author */}
+          <div className="flex items-center gap-2">
+            {post.author.profilePicture ? (
+              <Image
+                src={post.author.profilePicture}
+                alt={post.author.name}
+                width={28}
+                height={28}
+                className="rounded-full"
+              />
+            ) : (
+              <div className="w-7 h-7 rounded-full bg-primary/20 flex items-center justify-center">
+                <User className="w-3.5 h-3.5 text-primary" />
+              </div>
+            )}
+            <span className="font-medium text-foreground">{post.author.name}</span>
+          </div>
+
+          <span className="text-border">•</span>
+
+          {/* Date */}
+          <div className="flex items-center gap-1.5">
+            <Calendar className="h-3.5 w-3.5" />
+            <span>{formatDate(post.publishedAt)}</span>
+          </div>
+
+          <span className="text-border">•</span>
+
+          {/* Read time */}
+          <div className="flex items-center gap-1.5">
+            <Clock className="h-3.5 w-3.5" />
+            <span>{post.readTimeInMinutes} min read</span>
+          </div>
+        </div>
+
+        {/* Tags */}
+        {post.tags.length > 0 && (
+          <div className="flex flex-wrap gap-2 mb-8">
+            {post.tags.map((tag) => (
+              <Badge
+                key={tag.slug}
+                variant="outline"
+                className="text-xs px-3 py-1 bg-primary/5 border-primary/20 text-primary"
+              >
+                {tag.name}
+              </Badge>
+            ))}
+          </div>
+        )}
+
+        {/* Content */}
+        <div
+          className="blog-content"
+          dangerouslySetInnerHTML={{ __html: post.content.html }}
+        />
+
+        {/* Bottom back link */}
+        <div className="mt-12 pt-8 border-t border-border">
+          <Link
+            href="/blog"
+            className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors group"
+          >
+            <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-1" />
+            Back to Blog
+          </Link>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,77 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { fetchPortfolioData } from "@/lib/portfolio-api";
+import { fetchBlogPost, fetchBlogPosts } from "@/lib/hashnode-api";
+import { BlogPostClient } from "./blog-post-client";
+
+export const revalidate = 3600;
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const portfolioData = await fetchPortfolioData();
+  const host = portfolioData.blog?.hashnodeHost || "";
+  const post = await fetchBlogPost(host, slug);
+
+  if (!post) {
+    return {
+      title: "Post Not Found",
+      description: "The requested blog post could not be found.",
+    };
+  }
+
+  const title = post.seo?.title || post.title;
+  const description =
+    post.seo?.description || `${post.title} — Read on ${portfolioData.hero.heading || "my portfolio"}.`;
+  const coverUrl = post.coverImage?.url;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: "article",
+      publishedTime: post.publishedAt,
+      tags: post.tags.map((t) => t.name),
+      ...(coverUrl && {
+        images: [{ url: coverUrl, width: 1200, height: 630 }],
+      }),
+    },
+    twitter: {
+      card: coverUrl ? "summary_large_image" : "summary",
+      title,
+      description,
+      ...(coverUrl && { images: [coverUrl] }),
+    },
+  };
+}
+
+export async function generateStaticParams() {
+  try {
+    const portfolioData = await fetchPortfolioData();
+    const host = portfolioData.blog?.hashnodeHost || "";
+    if (!host) return [];
+
+    const posts = await fetchBlogPosts(host, 20);
+    return posts.map((post) => ({ slug: post.slug }));
+  } catch {
+    return [];
+  }
+}
+
+export default async function BlogPostPage({ params }: PageProps) {
+  const { slug } = await params;
+  const portfolioData = await fetchPortfolioData();
+  const host = portfolioData.blog?.hashnodeHost || "";
+  const post = await fetchBlogPost(host, slug);
+
+  if (!post) {
+    notFound();
+  }
+
+  return <BlogPostClient post={post} />;
+}

--- a/app/blog/blog-content.css
+++ b/app/blog/blog-content.css
@@ -1,0 +1,228 @@
+/* Blog content typography — scoped to .blog-content */
+
+.blog-content {
+  font-size: 1.125rem;
+  line-height: 1.8;
+  color: var(--foreground);
+}
+
+/* Headings */
+.blog-content h1 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
+  line-height: 1.3;
+  letter-spacing: -0.02em;
+  color: var(--foreground);
+}
+
+.blog-content h2 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+  color: var(--foreground);
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.blog-content h3 {
+  font-size: 1.375rem;
+  font-weight: 600;
+  margin-top: 1.75rem;
+  margin-bottom: 0.5rem;
+  line-height: 1.4;
+  color: var(--foreground);
+}
+
+.blog-content h4,
+.blog-content h5,
+.blog-content h6 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  color: var(--foreground);
+}
+
+/* Paragraphs */
+.blog-content p {
+  margin-bottom: 1.25rem;
+  color: var(--foreground);
+  opacity: 0.9;
+}
+
+/* Links */
+.blog-content a {
+  color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-color: var(--primary);
+  transition: opacity 0.2s;
+}
+
+.blog-content a:hover {
+  opacity: 0.8;
+}
+
+/* Lists */
+.blog-content ul,
+.blog-content ol {
+  margin-bottom: 1.25rem;
+  padding-left: 1.75rem;
+}
+
+.blog-content ul {
+  list-style-type: disc;
+}
+
+.blog-content ol {
+  list-style-type: decimal;
+}
+
+.blog-content li {
+  margin-bottom: 0.5rem;
+  color: var(--foreground);
+  opacity: 0.9;
+}
+
+.blog-content li > ul,
+.blog-content li > ol {
+  margin-top: 0.5rem;
+  margin-bottom: 0;
+}
+
+/* Blockquotes */
+.blog-content blockquote {
+  border-left: 4px solid var(--primary);
+  padding: 1rem 1.5rem;
+  margin: 1.5rem 0;
+  background: var(--muted);
+  border-radius: 0 0.5rem 0.5rem 0;
+  font-style: italic;
+}
+
+.blog-content blockquote p {
+  margin-bottom: 0;
+}
+
+/* Code - inline */
+.blog-content code {
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
+  font-size: 0.875em;
+  background: var(--muted);
+  padding: 0.2em 0.4em;
+  border-radius: 0.375rem;
+  color: var(--primary);
+  border: 1px solid var(--border);
+}
+
+/* Code - blocks */
+.blog-content pre {
+  margin: 1.5rem 0;
+  border-radius: 0.75rem;
+  overflow-x: auto;
+  background: var(--card) !important;
+  border: 1px solid var(--border);
+  padding: 1.25rem;
+}
+
+.blog-content pre code {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: 0.875rem;
+  line-height: 1.7;
+  color: var(--foreground);
+}
+
+/* Images */
+.blog-content img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.75rem;
+  margin: 1.5rem auto;
+  display: block;
+  border: 1px solid var(--border);
+}
+
+/* Tables */
+.blog-content table {
+  width: 100%;
+  margin: 1.5rem 0;
+  border-collapse: collapse;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.blog-content thead {
+  background: var(--muted);
+}
+
+.blog-content th {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--foreground);
+  border-bottom: 2px solid var(--border);
+}
+
+.blog-content td {
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  color: var(--foreground);
+  border-bottom: 1px solid var(--border);
+  opacity: 0.9;
+}
+
+.blog-content tr:last-child td {
+  border-bottom: none;
+}
+
+/* Horizontal rule */
+.blog-content hr {
+  margin: 2rem 0;
+  border: none;
+  border-top: 1px solid var(--border);
+}
+
+/* Strong / Bold */
+.blog-content strong {
+  font-weight: 700;
+  color: var(--foreground);
+}
+
+/* Emphasis */
+.blog-content em {
+  font-style: italic;
+}
+
+/* Keyboard input */
+.blog-content kbd {
+  font-family: ui-monospace, monospace;
+  font-size: 0.8em;
+  padding: 0.15em 0.4em;
+  border-radius: 0.25rem;
+  border: 1px solid var(--border);
+  background: var(--muted);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+}
+
+/* Embedded videos / iframes */
+.blog-content iframe {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 0.75rem;
+  margin: 1.5rem 0;
+  border: 1px solid var(--border);
+}
+
+/* First heading after cover doesn't need top margin */
+.blog-content > :first-child {
+  margin-top: 0;
+}

--- a/app/blog/blog-listing-client.tsx
+++ b/app/blog/blog-listing-client.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { motion } from "framer-motion";
+import { Calendar, Clock, ArrowLeft, Code2, Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import type { BlogPost } from "@/lib/hashnode-api";
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.08 },
+  },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.4 },
+  },
+};
+
+export function BlogListingClient({ posts }: { posts: BlogPost[] }) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+
+  // Collect all unique tags
+  const allTags = Array.from(
+    new Set(posts.flatMap((p) => p.tags.map((t) => t.name)))
+  ).sort();
+
+  // Filter posts
+  const filtered = posts.filter((post) => {
+    const matchesSearch =
+      !searchQuery ||
+      post.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      post.brief.toLowerCase().includes(searchQuery.toLowerCase());
+    const matchesTag =
+      !selectedTag || post.tags.some((t) => t.name === selectedTag);
+    return matchesSearch && matchesTag;
+  });
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
+        {/* Back link */}
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-8 group"
+        >
+          <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-1" />
+          Back to Portfolio
+        </Link>
+
+        {/* Header */}
+        <div className="mb-10">
+          <h1 className="text-4xl sm:text-5xl font-bold text-foreground mb-3 tracking-tight">
+            Blog
+          </h1>
+          <p className="text-lg text-muted-foreground max-w-2xl">
+            Thoughts, tutorials, and insights from my journey in software development.
+          </p>
+        </div>
+
+        {/* Search + Tag Filter */}
+        <div className="flex flex-col sm:flex-row gap-4 mb-8">
+          <div className="relative flex-1 max-w-md">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search posts..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pl-10 bg-card border-border"
+            />
+          </div>
+          {allTags.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant={selectedTag === null ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedTag(null)}
+                className="text-xs"
+              >
+                All
+              </Button>
+              {allTags.map((tag) => (
+                <Button
+                  key={tag}
+                  variant={selectedTag === tag ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setSelectedTag(selectedTag === tag ? null : tag)}
+                  className="text-xs"
+                >
+                  {tag}
+                </Button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Posts Grid */}
+        {filtered.length === 0 ? (
+          <div className="text-center py-20">
+            <Code2 className="w-16 h-16 text-muted-foreground/30 mx-auto mb-4" />
+            <h3 className="text-xl font-semibold text-foreground mb-2">No posts found</h3>
+            <p className="text-muted-foreground">
+              {searchQuery || selectedTag
+                ? "Try adjusting your search or filter."
+                : "No blog posts available yet."}
+            </p>
+          </div>
+        ) : (
+          <motion.div
+            className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+            variants={containerVariants}
+            initial="hidden"
+            animate="visible"
+          >
+            {filtered.map((post) => (
+              <motion.div key={post.id} variants={itemVariants}>
+                <Link href={`/blog/${post.slug}`} className="block h-full group">
+                  <Card className="h-full flex flex-col bg-card border-border/50 backdrop-blur-sm hover:shadow-lg hover:border-primary/20 transition-all duration-300 overflow-hidden">
+                    {/* Cover */}
+                    <div className="relative w-full h-48 bg-muted flex items-center justify-center overflow-hidden">
+                      {post.coverImage?.url ? (
+                        <Image
+                          src={post.coverImage.url}
+                          alt={post.title}
+                          width={500}
+                          height={300}
+                          className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+                        />
+                      ) : (
+                        <div className="flex items-center justify-center w-full h-full bg-gradient-to-br from-primary/10 to-accent/10">
+                          <Code2 className="w-16 h-16 text-primary/40" />
+                        </div>
+                      )}
+                      <div className="absolute top-3 right-3">
+                        <Badge
+                          variant="secondary"
+                          className="bg-background/80 backdrop-blur-md text-xs font-medium"
+                        >
+                          <Clock className="w-3 h-3 mr-1" />
+                          {post.readTimeInMinutes} min
+                        </Badge>
+                      </div>
+                    </div>
+
+                    <CardHeader className="pb-3">
+                      <CardTitle className="text-lg font-semibold text-foreground line-clamp-2 group-hover:text-primary transition-colors">
+                        {post.title}
+                      </CardTitle>
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1">
+                        <Calendar className="h-3.5 w-3.5 text-primary flex-shrink-0" />
+                        <span>{formatDate(post.publishedAt)}</span>
+                      </div>
+                    </CardHeader>
+
+                    <CardContent className="flex-grow flex flex-col gap-3">
+                      <CardDescription className="text-sm text-muted-foreground leading-relaxed line-clamp-3">
+                        {post.brief}
+                      </CardDescription>
+
+                      {post.tags.length > 0 && (
+                        <div className="flex flex-wrap gap-1.5 mt-auto pt-3 border-t border-border/30">
+                          {post.tags.slice(0, 3).map((tag) => (
+                            <Badge
+                              key={tag.slug}
+                              variant="outline"
+                              className="text-[10px] px-2 py-0.5 bg-primary/5 border-primary/20 text-primary"
+                            >
+                              {tag.name}
+                            </Badge>
+                          ))}
+                          {post.tags.length > 3 && (
+                            <Badge
+                              variant="outline"
+                              className="text-[10px] px-2 py-0.5 text-muted-foreground"
+                            >
+                              +{post.tags.length - 3}
+                            </Badge>
+                          )}
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
+                </Link>
+              </motion.div>
+            ))}
+          </motion.div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -1,0 +1,9 @@
+import "./blog-content.css";
+
+export default function BlogLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,34 @@
+import { Metadata } from "next";
+import { fetchPortfolioData } from "@/lib/portfolio-api";
+import { fetchBlogPosts } from "@/lib/hashnode-api";
+import { BlogListingClient } from "./blog-listing-client";
+
+export const revalidate = 3600; // ISR: revalidate every hour
+
+export async function generateMetadata(): Promise<Metadata> {
+  const portfolioData = await fetchPortfolioData();
+  const name = portfolioData.hero.heading || "Blog";
+
+  return {
+    title: `Blog — ${name}`,
+    description: `Read the latest blog posts, tutorials, and insights by ${name.replace("Hi, I'm ", "")}.`,
+    openGraph: {
+      title: `Blog — ${name}`,
+      description: `Read the latest blog posts, tutorials, and insights by ${name.replace("Hi, I'm ", "")}.`,
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `Blog — ${name}`,
+      description: `Read the latest blog posts, tutorials, and insights by ${name.replace("Hi, I'm ", "")}.`,
+    },
+  };
+}
+
+export default async function BlogPage() {
+  const portfolioData = await fetchPortfolioData();
+  const host = portfolioData.blog?.hashnodeHost || "";
+  const posts = await fetchBlogPosts(host, 20);
+
+  return <BlogListingClient posts={posts} />;
+}

--- a/components/custom/AdminDashboard.tsx
+++ b/components/custom/AdminDashboard.tsx
@@ -28,6 +28,7 @@ import {
     GraduationCap,
     Eye,
     EyeOff,
+    FileText,
 } from "lucide-react"
 import { updatePortfolioData } from "../../lib/portfolio-api"
 import type { PortfolioData } from "../../context/PortfolioContext"
@@ -38,6 +39,7 @@ import {
     sortableKeyboardCoordinates,
     verticalListSortingStrategy,
     useSortable,
+    arrayMove,
 } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
 import { formatHex, converter } from "culori"
@@ -97,6 +99,7 @@ interface SectionOrder {
     skills: number
     education: number
     contacts: number
+    blog: number
 }
 
 interface SortableItemProps {
@@ -149,6 +152,42 @@ const SortableItem: React.FC<SortableItemProps> = ({ id, section, order, isHidde
     )
 }
 
+// Sortable wrapper for project cards
+const SortableProjectCard: React.FC<{ id: string; children: React.ReactNode }> = ({ id, children }) => {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id })
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+        position: "relative" as const,
+        zIndex: isDragging ? 50 : "auto" as const,
+    }
+
+    return (
+        <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+            {children}
+        </div>
+    )
+}
+
+// Sortable wrapper for experience cards
+const SortableExperienceCard: React.FC<{ id: string; children: React.ReactNode }> = ({ id, children }) => {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id })
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+        position: "relative" as const,
+        zIndex: isDragging ? 50 : "auto" as const,
+    }
+
+    return (
+        <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+            {children}
+        </div>
+    )
+}
+
 export default function AdminDashboard() {
     const { isAuthenticated, data: portfolioData, refreshData } = usePortfolio()
     const router = useRouter()
@@ -163,6 +202,7 @@ export default function AdminDashboard() {
         skills: 5,
         education: 6,
         contacts: 7,
+        blog: 8,
     })
     const [selectedThemeMode, setSelectedThemeMode] = useState<"light" | "dark">("dark")
 
@@ -619,7 +659,7 @@ export default function AdminDashboard() {
         )
     }
 
-    // Drag and drop handler
+    // Drag and drop handler for sections
     const handleDragEnd = (event: any) => {
         const { active, over } = event
         if (!over || active.id === over.id) return
@@ -644,6 +684,34 @@ export default function AdminDashboard() {
 
         setSectionOrder(newOrder)
         setIsDirty(true)
+    }
+
+    // Drag and drop handler for projects
+    const handleProjectDragEnd = (event: any) => {
+        const { active, over } = event
+        if (!editedData || !over || active.id === over.id) return
+
+        const oldIndex = editedData.projects.findIndex((p) => p.id === active.id)
+        const newIndex = editedData.projects.findIndex((p) => p.id === over.id)
+
+        if (oldIndex === -1 || newIndex === -1) return
+
+        const newProjects = arrayMove(editedData.projects, oldIndex, newIndex)
+        updateField(["projects"], newProjects)
+    }
+
+    // Drag and drop handler for experience
+    const handleExperienceDragEnd = (event: any) => {
+        const { active, over } = event
+        if (!editedData || !over || active.id === over.id) return
+
+        const oldIndex = editedData.experience.findIndex((e) => e.id === active.id)
+        const newIndex = editedData.experience.findIndex((e) => e.id === over.id)
+
+        if (oldIndex === -1 || newIndex === -1) return
+
+        const newExperience = arrayMove(editedData.experience, oldIndex, newIndex)
+        updateField(["experience"], newExperience)
     }
 
     // Theme parsing function
@@ -809,7 +877,7 @@ export default function AdminDashboard() {
                 <div className="w-full">
                     <Tabs defaultValue="ordering" className="space-y-4">
                         <div className="overflow-x-auto">
-                            <TabsList className="grid w-full grid-cols-3 lg:grid-cols-9 bg-muted lg:min-w-max">
+                            <TabsList className="grid w-full grid-cols-3 lg:grid-cols-10 bg-muted lg:min-w-max">
                                 <TabsTrigger value="ordering" className="flex flex-col sm:flex-row items-center gap-1">
                                     <GripVertical className="h-4 w-4" />
                                     <span className="text-xs sm:text-sm hidden sm:inline">Ordering</span>
@@ -856,6 +924,13 @@ export default function AdminDashboard() {
                                 >
                                     <Mail className="h-3 w-3 lg:h-4 lg:w-4" />
                                     <span className="text-xs sm:text-sm hidden sm:inline">Contacts</span>
+                                </TabsTrigger>
+                                <TabsTrigger
+                                    value="blog"
+                                    className="flex flex-col sm:flex-row items-center gap-1 text-xs lg:text-sm"
+                                >
+                                    <FileText className="h-3 w-3 lg:h-4 lg:w-4" />
+                                    <span className="text-xs sm:text-sm hidden sm:inline">Blog</span>
                                 </TabsTrigger>
                                 <TabsTrigger value="theme" className="flex flex-col sm:flex-row items-center gap-1 text-xs lg:text-sm">
                                     <Palette className="h-4 w-4" />
@@ -1597,11 +1672,20 @@ export default function AdminDashboard() {
                                     </div>
                                 </div>
 
+                                <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleProjectDragEnd}>
+                                    <SortableContext
+                                        items={editedData.projects.map((p) => p.id)}
+                                        strategy={verticalListSortingStrategy}
+                                    >
                                 {editedData.projects.map((project, index) => (
-                                    <Card key={project.id} className="bg-card text-card-foreground border-border">
+                                    <SortableProjectCard key={project.id} id={project.id}>
+                                    <Card className="bg-card text-card-foreground border-border">
                                         <CardHeader>
                                             <div className="flex items-center justify-between">
-                                                <CardTitle className="text-base">Project {index + 1}</CardTitle>
+                                                <div className="flex items-center gap-2">
+                                                    <GripVertical className="h-4 w-4 text-muted-foreground cursor-grab active:cursor-grabbing" />
+                                                    <CardTitle className="text-base">Project {index + 1}</CardTitle>
+                                                </div>
                                                 <Button
                                                     onClick={() => removeProject(project.id)}
                                                     variant="outline"
@@ -1798,7 +1882,10 @@ export default function AdminDashboard() {
                                             </div>
                                         </CardContent>
                                     </Card>
+                                    </SortableProjectCard>
                                 ))}
+                                    </SortableContext>
+                                </DndContext>
                             </div>
                         </TabsContent>
 
@@ -1836,11 +1923,20 @@ export default function AdminDashboard() {
                                     </div>
                                 </div>
 
+                                <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleExperienceDragEnd}>
+                                    <SortableContext
+                                        items={editedData.experience.map((e) => e.id)}
+                                        strategy={verticalListSortingStrategy}
+                                    >
                                 {editedData.experience.map((exp, index) => (
-                                    <Card key={exp.id} className="bg-card text-card-foreground border-border">
+                                    <SortableExperienceCard key={exp.id} id={exp.id}>
+                                    <Card className="bg-card text-card-foreground border-border">
                                         <CardHeader>
                                             <div className="flex items-center justify-between">
-                                                <CardTitle className="text-base">Experience {index + 1}</CardTitle>
+                                                <div className="flex items-center gap-2">
+                                                    <GripVertical className="h-4 w-4 text-muted-foreground cursor-grab active:cursor-grabbing" />
+                                                    <CardTitle className="text-base">Experience {index + 1}</CardTitle>
+                                                </div>
                                                 <Button
                                                     onClick={() => removeExperience(exp.id)}
                                                     variant="outline"
@@ -2070,7 +2166,10 @@ export default function AdminDashboard() {
                                             </div>
                                         </CardContent>
                                     </Card>
+                                    </SortableExperienceCard>
                                 ))}
+                                    </SortableContext>
+                                </DndContext>
                             </div>
                         </TabsContent>
 
@@ -2582,6 +2681,61 @@ export default function AdminDashboard() {
 
                                 {/* Skills Section */}
 
+                            </div>
+                        </TabsContent>
+
+                        {/* Blog Section */}
+                        <TabsContent value="blog">
+                            <div className="space-y-4">
+                                <div className="flex items-center justify-between">
+                                    <div>
+                                        <h3 className="text-lg font-semibold">Blog</h3>
+                                        <p className="text-sm text-muted-foreground">Configure your Hashnode blog integration</p>
+                                    </div>
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() => toggleSectionVisibility("blog")}
+                                        className={sectionOrder.blog === 0 ? "text-green-600" : "text-red-600"}
+                                    >
+                                        {sectionOrder.blog === 0 ? (
+                                            <>
+                                                <Eye className="mr-2 h-4 w-4" />
+                                                Show Section
+                                            </>
+                                        ) : (
+                                            <>
+                                                <EyeOff className="mr-2 h-4 w-4" />
+                                                Hide Section
+                                            </>
+                                        )}
+                                    </Button>
+                                </div>
+
+                                <Card className="bg-card text-card-foreground border-border">
+                                    <CardHeader>
+                                        <CardTitle>Hashnode Configuration</CardTitle>
+                                        <CardDescription>
+                                            Enter your Hashnode blog URL to fetch and display your blog posts on the portfolio.
+                                            Blog posts are fetched automatically — no manual entry needed.
+                                        </CardDescription>
+                                    </CardHeader>
+                                    <CardContent className="space-y-4">
+                                        <div className="space-y-2">
+                                            <Label htmlFor="hashnode-host">Hashnode Blog URL</Label>
+                                            <Input
+                                                id="hashnode-host"
+                                                value={editedData.blog?.hashnodeHost || ""}
+                                                onChange={(e) => updateField(["blog", "hashnodeHost"], e.target.value)}
+                                                className="bg-background border-input"
+                                                placeholder="e.g., yourusername.hashnode.dev"
+                                            />
+                                            <p className="text-xs text-muted-foreground">
+                                                Your Hashnode publication host (e.g., <code className="text-primary">eahtasham.hashnode.dev</code> or a custom domain like <code className="text-primary">blog.yourdomain.com</code>)
+                                            </p>
+                                        </div>
+                                    </CardContent>
+                                </Card>
                             </div>
                         </TabsContent>
 

--- a/components/custom/HomePage.tsx
+++ b/components/custom/HomePage.tsx
@@ -8,6 +8,7 @@ import { ExperienceSection } from "./sections/ExperienceSection"
 import { EducationSection } from "./sections/EducationSection"
 import { SkillsSection } from "./sections/SkillsSection"
 import { ContactSection } from "./sections/ContactSection"
+import { BlogSection } from "./sections/BlogSection"
 import { Nav } from "./Nav"
 import { Footer } from "./Footer"
 import { ParticleBackground } from "./particle-background"
@@ -31,6 +32,7 @@ export default function HomePage() {
     education: <EducationSection key="education" />,
     skills: <SkillsSection key="skills" />,
     contacts: <ContactSection key="contacts" />,
+    blog: <BlogSection key="blog" />,
   }
 
   // Filter out sections with order 0

--- a/components/custom/sections/BlogSection.tsx
+++ b/components/custom/sections/BlogSection.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { motion } from "framer-motion";
+import { Calendar, Clock, ArrowRight, Code2 } from "lucide-react";
+import { usePortfolio } from "@/context/PortfolioContext";
+import { fetchBlogPosts, type BlogPost } from "@/lib/hashnode-api";
+import { Button } from "@/components/ui/button";
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.15,
+    },
+  },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 30 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 0.6,
+      ease: [0.25, 0.46, 0.45, 0.94] as const,
+    },
+  },
+};
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function BlogCardSkeleton() {
+  return (
+    <Card className="h-full flex flex-col bg-card border-border/50 backdrop-blur-sm overflow-hidden animate-pulse">
+      <div className="w-full h-48 sm:h-52 bg-muted" />
+      <CardHeader className="pb-3">
+        <div className="h-5 bg-muted rounded w-3/4 mb-2" />
+        <div className="h-4 bg-muted rounded w-1/2" />
+      </CardHeader>
+      <CardContent className="flex-grow flex flex-col gap-3">
+        <div className="space-y-2">
+          <div className="h-3 bg-muted rounded w-full" />
+          <div className="h-3 bg-muted rounded w-5/6" />
+          <div className="h-3 bg-muted rounded w-2/3" />
+        </div>
+        <div className="flex gap-2 mt-auto">
+          <div className="h-5 bg-muted rounded-full w-16" />
+          <div className="h-5 bg-muted rounded-full w-20" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export const BlogSection = () => {
+  const { data } = usePortfolio();
+  const [posts, setPosts] = useState<BlogPost[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const hashnodeHost = data.blog?.hashnodeHost;
+
+  useEffect(() => {
+    if (!hashnodeHost) {
+      setLoading(false);
+      return;
+    }
+
+    fetchBlogPosts(hashnodeHost, 3)
+      .then((fetchedPosts) => setPosts(fetchedPosts))
+      .catch(() => setPosts([]))
+      .finally(() => setLoading(false));
+  }, [hashnodeHost]);
+
+  if (!hashnodeHost) return null;
+  if (!loading && posts.length === 0) return null;
+
+  return (
+    <div className="w-full py-12 md:py-20 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-7xl mx-auto">
+        {/* Header */}
+        <div className="mb-12 md:mb-16 text-center">
+          <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-foreground mb-4 tracking-tight">
+            Latest Blog Posts
+          </h2>
+          <p className="text-base sm:text-lg text-muted-foreground max-w-2xl mx-auto">
+            Thoughts, tutorials, and insights from my journey in software development.
+          </p>
+        </div>
+
+        {/* Loading */}
+        {loading ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8">
+            {[1, 2, 3].map((i) => (
+              <BlogCardSkeleton key={i} />
+            ))}
+          </div>
+        ) : (
+          <>
+            {/* Posts Grid */}
+            <motion.div
+              className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8"
+              variants={containerVariants}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true, margin: "-100px" }}
+            >
+              {posts.map((post) => (
+                <motion.div key={post.id} variants={itemVariants}>
+                  <Link href={`/blog/${post.slug}`} className="block h-full group">
+                    <Card className="h-full flex flex-col bg-card border-border/50 backdrop-blur-sm hover:shadow-lg hover:border-primary/20 transition-all duration-300 overflow-hidden">
+                      {/* Cover Image or Fallback */}
+                      <div className="relative w-full h-48 sm:h-52 bg-muted flex items-center justify-center overflow-hidden">
+                        {post.coverImage?.url ? (
+                          <Image
+                            src={post.coverImage.url}
+                            alt={post.title}
+                            width={500}
+                            height={300}
+                            className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+                          />
+                        ) : (
+                          <div className="flex items-center justify-center w-full h-full bg-gradient-to-br from-primary/10 to-accent/10">
+                            <Code2 className="w-16 h-16 text-primary/40" />
+                          </div>
+                        )}
+                        {/* Read time overlay */}
+                        <div className="absolute top-3 right-3">
+                          <Badge
+                            variant="secondary"
+                            className="bg-background/80 backdrop-blur-md text-xs font-medium"
+                          >
+                            <Clock className="w-3 h-3 mr-1" />
+                            {post.readTimeInMinutes} min read
+                          </Badge>
+                        </div>
+                      </div>
+
+                      <CardHeader className="pb-3">
+                        <CardTitle className="text-lg sm:text-xl font-semibold text-foreground line-clamp-2 group-hover:text-primary transition-colors duration-200">
+                          {post.title}
+                        </CardTitle>
+                        <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1">
+                          <Calendar className="h-3.5 w-3.5 text-primary flex-shrink-0" />
+                          <span>{formatDate(post.publishedAt)}</span>
+                        </div>
+                      </CardHeader>
+
+                      <CardContent className="flex-grow flex flex-col gap-4">
+                        <CardDescription className="text-xs sm:text-sm text-muted-foreground leading-relaxed line-clamp-3">
+                          {post.brief}
+                        </CardDescription>
+
+                        {/* Tags */}
+                        {post.tags.length > 0 && (
+                          <div className="flex flex-wrap gap-1.5 mt-auto pt-3 border-t border-border/30">
+                            {post.tags.slice(0, 3).map((tag) => (
+                              <Badge
+                                key={tag.slug}
+                                variant="outline"
+                                className="text-[10px] sm:text-xs px-2 py-0.5 bg-primary/5 border-primary/20 text-primary"
+                              >
+                                {tag.name}
+                              </Badge>
+                            ))}
+                            {post.tags.length > 3 && (
+                              <Badge
+                                variant="outline"
+                                className="text-[10px] sm:text-xs px-2 py-0.5 text-muted-foreground"
+                              >
+                                +{post.tags.length - 3}
+                              </Badge>
+                            )}
+                          </div>
+                        )}
+                      </CardContent>
+                    </Card>
+                  </Link>
+                </motion.div>
+              ))}
+            </motion.div>
+
+            {/* View All Button */}
+            <div className="flex justify-center mt-10">
+              <Link href="/blog">
+                <Button
+                  variant="outline"
+                  size="lg"
+                  className="group px-8 py-4 text-base border-2 hover:bg-primary hover:text-primary-foreground hover:border-primary transition-all duration-300"
+                >
+                  View All Posts
+                  <ArrowRight className="ml-2 h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
+                </Button>
+              </Link>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BlogSection;

--- a/components/custom/sections/HeroSection.tsx
+++ b/components/custom/sections/HeroSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Download, Github, MapPin } from "lucide-react";
+import { Download, Github, MapPin, Twitter } from "lucide-react";
 import Image from "next/image";
 import React from "react";
 import { FlipWords } from "@/components/external-ui/flip-words";
@@ -137,12 +137,12 @@ const HeroContent = ({ hero, centered = false, email }: { hero: any; centered?: 
     {/* Buttons */}
     <div className={`flex flex-col sm:flex-row gap-4 ${centered ? "justify-center" : ""}`}>
       <Link href={`mailto:${email}`} target="_blank" rel="noopener noreferrer">
-      <Button
-        size="lg"
-        className="px-8 py-4 bg-primary hover:bg-primary/80 shadow-lg hover:shadow-xl text-lg"
-      >
-        {hero.cta}
-      </Button>
+        <Button
+          size="lg"
+          className="px-8 py-4 bg-primary hover:bg-primary/80 shadow-lg hover:shadow-xl text-lg"
+        >
+          {hero.cta}
+        </Button>
       </Link>
       {hero.downloadCV && (
         <Button
@@ -175,7 +175,9 @@ const HeroContent = ({ hero, centered = false, email }: { hero: any; centered?: 
 
             <div className="relative z-10 flex items-center justify-center w-8 h-8 group-hover:scale-130 group-hover:rotate-3 transition-transform duration-300 ease-out">
               {link.name.toLowerCase() === "github" ? (
-                <Github className="w-7 h-7 text-black dark:text-white transition-colors duration-300" />
+                <Github className="w-7 h-7 text-foreground transition-colors duration-300" />
+              ) : link.name.toLowerCase() === "x" || link.name.toLowerCase() === "twitter" ? (
+                <Twitter className="w-7 h-7 text-foreground transition-colors duration-300" />
               ) : (
                 <Image
                   src={getDeviconUrl(link.name)}

--- a/context/PortfolioContext.tsx
+++ b/context/PortfolioContext.tsx
@@ -20,6 +20,7 @@ export interface PortfolioData {
     skills: number;
     education: number;
     contacts: number;
+    blog: number;
   };
   hero: {
     heading: string;
@@ -135,6 +136,9 @@ export interface PortfolioData {
     discord?: string;
     telegram?: string;
   };
+  blog: {
+    hashnodeHost: string;
+  };
 }
 
 interface PortfolioContextType {
@@ -160,7 +164,21 @@ export const PortfolioProvider = ({ children, initialData }: PortfolioProviderPr
   const [data, setData] = useState<PortfolioData>(initialData);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      const stored = localStorage.getItem("portfolio_auth");
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        // Check if token hasn't expired (24 hours)
+        if (parsed.expiry && Date.now() < parsed.expiry) {
+          return true;
+        }
+        localStorage.removeItem("portfolio_auth");
+      }
+    } catch {}
+    return false;
+  });
 
   const refreshData = async () => {
     setLoading(true);
@@ -254,6 +272,12 @@ export const PortfolioProvider = ({ children, initialData }: PortfolioProviderPr
 
     if (email === adminEmail && password === adminPassword) {
       setIsAuthenticated(true);
+      try {
+        localStorage.setItem("portfolio_auth", JSON.stringify({
+          authenticated: true,
+          expiry: Date.now() + 24 * 60 * 60 * 1000, // 24 hours
+        }));
+      } catch {}
       return true;
     }
     return false;
@@ -261,6 +285,9 @@ export const PortfolioProvider = ({ children, initialData }: PortfolioProviderPr
 
   const logout = () => {
     setIsAuthenticated(false);
+    try {
+      localStorage.removeItem("portfolio_auth");
+    } catch {}
   };
 
   // Apply theme on mount

--- a/lib/hashnode-api.ts
+++ b/lib/hashnode-api.ts
@@ -1,0 +1,165 @@
+// lib/hashnode-api.ts
+// Hashnode GraphQL API client — no API key needed for public reads
+
+const GQL_ENDPOINT = "https://gql.hashnode.com";
+
+// --- Types ---
+
+export interface BlogPost {
+  id: string;
+  title: string;
+  slug: string;
+  brief: string;
+  publishedAt: string;
+  readTimeInMinutes: number;
+  coverImage: { url: string } | null;
+  tags: Array<{ name: string; slug: string }>;
+}
+
+export interface BlogPostDetail {
+  id: string;
+  title: string;
+  subtitle: string | null;
+  publishedAt: string;
+  readTimeInMinutes: number;
+  content: { html: string };
+  coverImage: { url: string } | null;
+  tags: Array<{ name: string; slug: string }>;
+  author: {
+    name: string;
+    profilePicture: string | null;
+  };
+  seo: {
+    title: string | null;
+    description: string | null;
+  } | null;
+}
+
+// --- Queries ---
+
+const POSTS_QUERY = `
+  query GetPosts($host: String!, $first: Int!) {
+    publication(host: $host) {
+      posts(first: $first) {
+        edges {
+          node {
+            id
+            title
+            slug
+            brief
+            publishedAt
+            readTimeInMinutes
+            coverImage {
+              url
+            }
+            tags {
+              name
+              slug
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const POST_BY_SLUG_QUERY = `
+  query GetPostBySlug($host: String!, $slug: String!) {
+    publication(host: $host) {
+      post(slug: $slug) {
+        id
+        title
+        subtitle
+        publishedAt
+        readTimeInMinutes
+        content {
+          html
+        }
+        coverImage {
+          url
+        }
+        tags {
+          name
+          slug
+        }
+        author {
+          name
+          profilePicture
+        }
+        seo {
+          title
+          description
+        }
+      }
+    }
+  }
+`;
+
+// --- Fetch functions ---
+
+async function queryHashnode<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+  const response = await fetch(GQL_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+    next: { revalidate: 3600 }, // Cache for 1 hour
+  });
+
+  if (!response.ok) {
+    throw new Error(`Hashnode API error: ${response.status} ${response.statusText}`);
+  }
+
+  const result = await response.json();
+
+  if (result.errors) {
+    throw new Error(`Hashnode GraphQL error: ${result.errors[0]?.message || "Unknown error"}`);
+  }
+
+  return result.data;
+}
+
+/**
+ * Fetch a list of blog posts from a Hashnode publication.
+ */
+export async function fetchBlogPosts(host: string, first: number = 10): Promise<BlogPost[]> {
+  if (!host) return [];
+
+  try {
+    const data = await queryHashnode<{
+      publication: {
+        posts: {
+          edges: Array<{ node: BlogPost }>;
+        };
+      } | null;
+    }>(POSTS_QUERY, { host, first });
+
+    if (!data.publication?.posts?.edges) return [];
+
+    return data.publication.posts.edges.map((edge) => edge.node);
+  } catch (error) {
+    console.error("Error fetching blog posts:", error);
+    return [];
+  }
+}
+
+/**
+ * Fetch a single blog post by slug from a Hashnode publication.
+ */
+export async function fetchBlogPost(host: string, slug: string): Promise<BlogPostDetail | null> {
+  if (!host || !slug) return null;
+
+  try {
+    const data = await queryHashnode<{
+      publication: {
+        post: BlogPostDetail | null;
+      } | null;
+    }>(POST_BY_SLUG_QUERY, { host, slug });
+
+    return data.publication?.post || null;
+  } catch (error) {
+    console.error("Error fetching blog post:", error);
+    return null;
+  }
+}

--- a/lib/portfolio-api.ts
+++ b/lib/portfolio-api.ts
@@ -61,7 +61,8 @@ const defaultData: PortfolioData = {
     experience: 4,
     skills: 5,
     education: 6,
-    contacts: 7
+    contacts: 7,
+    blog: 8,
   },
   hero: {
     heading: "Hi, I'm Eahtasham",
@@ -111,6 +112,9 @@ const defaultData: PortfolioData = {
     twitter: "https://twitter.com/johndoe",
     github: "https://github.com/johndoe",
     linkedin: "https://linkedin.com/in/johndoe",
+  },
+  blog: {
+    hashnodeHost: "eahtasham.hashnode.dev",
   },
 };
 


### PR DESCRIPTION


Blog Section:
- Add Hashnode GraphQL API client (lib/hashnode-api.ts) for fetching posts
- Add BlogSection component showing 3 latest posts on landing page
- Add /blog listing page with search and tag filtering (ISR, 1hr)
- Add /blog/[slug] clean reading-focused post page with full SEO
- Add blog content typography CSS for rendered Hashnode HTML
- Add Blog tab in admin panel with configurable Hashnode URL
- Add blog to sectionOrder (draggable/hideable like other sections)
- Use </> code icon fallback for posts without cover images

Admin - Drag & Drop:
- Add drag-and-drop reordering for project items via @dnd-kit
- Add drag-and-drop reordering for experience items via @dnd-kit
- Add grip handles to project and experience cards

Auth Persistence:
- Store auth state in localStorage with 24hr expiry token
- Restore auth on page load, clear on logout

Dark Mode Fix:
- Add Twitter/X icon handling via Lucide (like GitHub)
- Add dark:invert filter to devicon-loaded social SVGs
- Fix GitHub icon to use text-foreground instead of hardcoded colors